### PR TITLE
Hotfix/#34

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -714,13 +714,13 @@ Query.prototype.count = function(callback) {
             return promisor._onExecuteResult(err);
         }
 
-        try {
-            callback(undefined, result[0]["COUNT(0)"]);
-            promisor._onExecuteResult(undefined, result[0]["COUNT(0)"]);
-        } catch(e) {
-            callback(undefined, 0);
-            promisor._onExecuteResult(undefined, 0);
+        var count = 0;
+        if(result && result[0]) {
+            count = parseInt(result[0]["COUNT(0)"]) || 0;
         }
+
+        callback(undefined, result[0]["COUNT(0)"]);
+        promisor._onExecuteResult(undefined, result[0]["COUNT(0)"]);
     });
 
     return promisor;

--- a/lib/query.js
+++ b/lib/query.js
@@ -719,8 +719,8 @@ Query.prototype.count = function(callback) {
             count = parseInt(result[0]["COUNT(0)"]) || 0;
         }
 
-        callback(undefined, result[0]["COUNT(0)"]);
-        promisor._onExecuteResult(undefined, result[0]["COUNT(0)"]);
+        callback(undefined, count);
+        promisor._onExecuteResult(undefined, count);
     });
 
     return promisor;

--- a/package.json
+++ b/package.json
@@ -7,12 +7,12 @@
     "test": "test"
   },
   "dependencies": {
-    "async": "^1.5.0",
-    "bluebird": "^3.0.6",
+    "async": "^1.5.2",
+    "bluebird": "^3.1.1",
     "colors": "^1.1.2",
     "fbbk-json": "^0.0.8",
-    "lodash": "^3.10.1",
-    "moment": "^2.10.6",
+    "lodash": "^4.0.0",
+    "moment": "^2.11.1",
     "mysql2": "^0.15.8",
     "scarlet-task": "^0.1.0-comment",
     "toshihiko-memcached": "^1.0.0"

--- a/test/issues.js
+++ b/test/issues.js
@@ -82,6 +82,23 @@ describe("issues", function () {
         });
     });
 
+    describe("error", function() {
+        it("should fix #34, Model.count 的时候，在 callback 函数里面 throw Error 会触发两次 callback", function(done) {
+            var originalException = process.listeners("uncaughtException").pop();
+            process.removeListener("uncaughtException", originalException);
+            process.once("uncaughtException", function(err) {
+                err.message.should.be.eql("0");
+                process.on("uncaughtException", originalException);
+                done();
+            });
+
+            var i = 0;
+            Model.count(function() {
+                throw new Error(i++);
+            });
+        });
+    });
+
     describe("generate", function() {
         it("should fix #32, 逻辑运算 AND 或者 OR 的时候有 NULL 时发生的 Bug", function(done) {
             var sql = Model.where({ key1: { $neq: [ 0, null ] } }).makeSQL("find");


### PR DESCRIPTION
`Model.count` 的时候，在 `callback` 函数里面 `throw Error` 会触发两次 `callback`。

``` javascript
Foo.count(function(err, count) {
    console.log(count);
    throw Error('...');
});
```

这段代码的 `callback` 会被多次触发。
