### PR TITLE
fix the bug: null is not equl to false(or 0, '')

### DIFF
--- a/lib/yukari.js
+++ b/lib/yukari.js
@@ -426,6 +426,17 @@ Yukari.prototype.update = function(callback) {
             fieldType.$equal.bind(fieldType) :
             field.type.equal.bind(field.type));
 
+        // null not equal to false or 0 or ''
+        if((null === this[key] || null === this.$origData[key].data) && 
+            this[key] !== this.$origData[key].data && 
+            field.allowNull) {
+            data[field.name] = {
+                data    : this[key],
+                field   : field
+            };
+            continue;
+        }
+
         // only change changed data
         if(!equalFunc(this[key], this.$origData[key].data)) {
             data[field.name] = {

--- a/lib/yukari.js
+++ b/lib/yukari.js
@@ -47,14 +47,14 @@ Yukari.prototype._getPrimaryKeys = function(fromOrig) {
     var keys = this.$model.getPrimaryKeysName();
     if(typeof keys === "string") {
         return (fromOrig || this[keys] === undefined) ?
-            this.$origData[keys] :
+            this.$origData[keys].data :
             this[keys];
     }
 
     var obj = {};
     for(var i = 0; i < keys.length; i++) {
         obj[keys[i]] = (fromOrig || this[keys[i]] === undefined) ?
-            this.$origData[keys[i]] :
+            this.$origData[keys[i]].data :
             this[keys[i]];
     }
     return obj;

--- a/test/yukari.js
+++ b/test/yukari.js
@@ -26,6 +26,7 @@ describe("yukari", function () {
             "`key2` float NOT NULL," +
             "`key3` varchar(200) NOT NULL DEFAULT ''," +
             "`key4` varchar(200) NOT NULL DEFAULT ''," +
+            "`key5` int(11) NULL DEFAULT NULL," +
             "PRIMARY KEY (`id`)" +
             ") ENGINE=InnoDB DEFAULT CHARSET=utf8;";
         toshihiko.execute(sql, done);
@@ -45,7 +46,8 @@ describe("yukari", function () {
                 ]
             },
             { name: "key3", type: T.Type.Json, defaultValue: {} },
-            { name: "key4", type: T.Type.String, defaultValue:"Ha!"}
+            { name: "key4", type: T.Type.String, defaultValue:"Ha!"},
+            { name: "key5", type: T.Type.Boolean, allowNull: true, defaultValue: null }
         ]);
 
         yukari = Model.build({
@@ -91,7 +93,46 @@ describe("yukari", function () {
             done();
         });
     });
-    it("update by jsonData", function (done) {
+    it("#check value is null", function(done) {
+        Model.where({key1: 1}).findOne(function(err, y) {
+            should.ifError(err);
+            should(y.key5).equal(null);
+            done();
+        });
+    });
+    it("#update value null to false", function (done) {
+        yukari.key2 = 4;
+        yukari.key5 = false;
+        yukari.update(function(err, data) {
+            should.ifError(err);
+            data.should.be.eql(yukari);
+            done();
+        });
+    });
+    it("#check value set to be false", function(done) {
+        Model.where({key1: 1}).findOne(function(err, y) {
+            should.ifError(err);
+            should(y.key5).be.exactly(false);
+            done();
+        });
+    });
+    it("#update value false to null", function (done) {
+        yukari.key2 = 3;
+        yukari.key5 = null;
+        yukari.update(function(err, data) {
+            should.ifError(err);
+            data.should.be.eql(yukari);
+            done();
+        });
+    });
+    it("#check value set to be null", function(done) {
+        Model.where({key1: 1}).findOne(function(err, y) {
+            should.ifError(err);
+            should(y.key5).equal(null);
+            done();
+        });
+    });
+    it("#update by jsonData", function (done) {
         yukari.updateByJson({key2: 5}, function(err, data) {
             should.ifError(err);
             data.should.be.eql(yukari);


### PR DESCRIPTION
Fix the bug about yukari's update. When the key set the property `allowNull: true` and the key's original value is `null`, then set the key to `false` (or `0`,` ''`),the value should be set and change but not.